### PR TITLE
fix request media type for v2

### DIFF
--- a/lib/outreach/request.rb
+++ b/lib/outreach/request.rb
@@ -71,7 +71,7 @@ module Outreach
     end
 
     def auth_header
-      headers = { 'Content-Type' => 'application/json' }
+      headers = { 'Content-Type' => 'application/vnd.api+json' }
       headers["Authorization"] = "Bearer #{@access_token}" if @access_token
       headers
     end


### PR DESCRIPTION
Outreach v2 API needs `Content-Type` set to `application/vnd.api+json` in order to parse the requests correctly.